### PR TITLE
Add support for parsing JS objects

### DIFF
--- a/Electrino/win10/Electrino/App.xaml.cs
+++ b/Electrino/win10/Electrino/App.xaml.cs
@@ -17,6 +17,7 @@ using Windows.UI.Xaml.Navigation;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Windows.Storage;
+using Windows.UI.ViewManagement;
 
 namespace Electrino
 {
@@ -90,18 +91,21 @@ namespace Electrino
             }
         }
 
-        public static void NewWindow()
+        public static void NewWindow(int width, int height)
         {
             if (instance == null)
             {
                 Log("App no ready yet");
                 return;
             }
-            App.instance._NewWindow();
+            App.instance._NewWindow(width, height);
         }
 
-        private void _NewWindow()
+        private void _NewWindow(int width, int height)
         {
+            ApplicationView.PreferredLaunchViewSize = new Size(width, height);
+            ApplicationView.PreferredLaunchWindowingMode = ApplicationViewWindowingMode.PreferredLaunchViewSize;            
+
             Frame rootFrame = Window.Current.Content as Frame;
 
             // Do not repeat app initialization when the Window already has content,
@@ -113,7 +117,6 @@ namespace Electrino
 
                 rootFrame.NavigationFailed += OnNavigationFailed;
                 
-
                 // Place the frame in the current Window
                 Window.Current.Content = rootFrame;
             }
@@ -127,7 +130,6 @@ namespace Electrino
             }
             // Ensure the current window is active
             Window.Current.Activate();
-
         }
 
         /// <summary>

--- a/Electrino/win10/Electrino/Electrino.csproj
+++ b/Electrino/win10/Electrino/Electrino.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Hosting\JavaScriptValueType.cs" />
     <Compile Include="Hosting\Native.cs" />
     <Compile Include="JavaScriptApp.cs" />
+    <Compile Include="JS\JavaScriptValueToJTokenConverter.cs" />
     <Compile Include="JS\JSApp.cs" />
     <Compile Include="JS\JSBrowserWindow.cs" />
     <Compile Include="JS\JSConsole.cs" />
@@ -171,6 +172,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>5.3.3</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>10.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Electrino/win10/Electrino/Electrino.csproj
+++ b/Electrino/win10/Electrino/Electrino.csproj
@@ -135,6 +135,7 @@
     <Compile Include="JS\JSProcess.cs" />
     <Compile Include="JS\JSRequire.cs" />
     <Compile Include="JS\JSUrl.cs" />
+    <Compile Include="JS\JTokenToJavaScriptValueConverter.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/Electrino/win10/Electrino/JS/JTokenToJavaScriptValueConverter.cs
+++ b/Electrino/win10/Electrino/JS/JTokenToJavaScriptValueConverter.cs
@@ -1,0 +1,114 @@
+﻿using ChakraHost.Hosting;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace Electrino.JS
+{
+    // Borrowed from: https://www.microsoft.com/reallifecode/2016/06/02/hybrid-apps-using-c-and-javascript-with-chakracore/
+    public sealed class JTokenToJavaScriptValueConverter
+    {
+        private static readonly JTokenToJavaScriptValueConverter s_instance =
+            new JTokenToJavaScriptValueConverter();
+
+        private JTokenToJavaScriptValueConverter() { }
+
+        public static JavaScriptValue Convert(JToken token)
+        {
+            return s_instance.Visit(token);
+        }
+
+        private JavaScriptValue Visit(JToken token)
+        {
+            if (token == null)
+                throw new ArgumentNullException(nameof(token));
+
+            switch (token.Type)
+            {
+                case JTokenType.Array:
+                    return VisitArray((JArray)token);
+                case JTokenType.Boolean:
+                    return VisitBoolean((JValue)token);
+                case JTokenType.Float:
+                    return VisitFloat((JValue)token);
+                case JTokenType.Integer:
+                    return VisitInteger((JValue)token);
+                case JTokenType.Null:
+                    return VisitNull(token);
+                case JTokenType.Object:
+                    return VisitObject((JObject)token);
+                case JTokenType.String:
+                    return VisitString((JValue)token);
+                case JTokenType.Undefined:
+                    return VisitUndefined(token);
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        private JavaScriptValue VisitArray(JArray token)
+        {
+            var n = token.Count;
+            var array = AddRef(JavaScriptValue.CreateArray((uint)n));
+            for (var i = 0; i < n; ++i)
+            {
+                var value = Visit(token[i]);
+                array.SetIndexedProperty(JavaScriptValue.FromInt32(i), value);
+                value.Release();
+            }
+
+            return array;
+        }
+
+        private JavaScriptValue VisitBoolean(JValue token)
+        {
+            return token.Value<bool>()
+                ? JavaScriptValue.True
+                : JavaScriptValue.False;
+        }
+
+        private JavaScriptValue VisitFloat(JValue token)
+        {
+            return AddRef(JavaScriptValue.FromDouble(token.Value<double>()));
+        }
+
+        private JavaScriptValue VisitInteger(JValue token)
+        {
+            return AddRef(JavaScriptValue.FromDouble(token.Value<double>()));
+        }
+
+        private JavaScriptValue VisitNull(JToken token)
+        {
+            return JavaScriptValue.Null;
+        }
+
+        private JavaScriptValue VisitObject(JObject token)
+        {
+            var jsonObject = AddRef(JavaScriptValue.CreateObject());
+            foreach (var entry in token)
+            {
+                var value = Visit(entry.Value);
+                var propertyId = JavaScriptPropertyId.FromString(entry.Key);
+                jsonObject.SetProperty(propertyId, value, true);
+                value.Release();
+            }
+
+            return jsonObject;
+        }
+
+        private JavaScriptValue VisitString(JValue token)
+        {
+            return AddRef(JavaScriptValue.FromString(token.Value<string>()));
+        }
+
+        private JavaScriptValue VisitUndefined(JToken token)
+        {
+            return JavaScriptValue.Undefined;
+        }
+
+        private JavaScriptValue AddRef(JavaScriptValue value)
+        {
+            value.AddRef();
+            return value;
+        }
+    }
+}

--- a/Electrino/win10/Electrino/JS/JavaScriptValueToJTokenConverter.cs
+++ b/Electrino/win10/Electrino/JS/JavaScriptValueToJTokenConverter.cs
@@ -4,6 +4,7 @@ using System;
 
 namespace Electrino.JS
 {
+    // Borrowed from: https://www.microsoft.com/reallifecode/2016/06/02/hybrid-apps-using-c-and-javascript-with-chakracore/
     public sealed class JavaScriptValueToJTokenConverter
     {
         private static readonly JToken s_true = new JValue(true);

--- a/Electrino/win10/Electrino/JS/JavaScriptValueToJTokenConverter.cs
+++ b/Electrino/win10/Electrino/JS/JavaScriptValueToJTokenConverter.cs
@@ -1,0 +1,107 @@
+﻿using ChakraHost.Hosting;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace Electrino.JS
+{
+    public sealed class JavaScriptValueToJTokenConverter
+    {
+        private static readonly JToken s_true = new JValue(true);
+        private static readonly JToken s_false = new JValue(false);
+        private static readonly JToken s_null = JValue.CreateNull();
+        private static readonly JToken s_undefined = JValue.CreateUndefined();
+
+        private static readonly JavaScriptValueToJTokenConverter s_instance =
+                new JavaScriptValueToJTokenConverter();
+
+        private JavaScriptValueToJTokenConverter() { }
+
+        public static JToken Convert(JavaScriptValue value)
+        {
+            return s_instance.Visit(value);
+        }
+
+        private JToken Visit(JavaScriptValue value)
+        {
+            switch (value.ValueType)
+            {
+                case JavaScriptValueType.Array:
+                    return VisitArray(value);
+                case JavaScriptValueType.Boolean:
+                    return VisitBoolean(value);
+                case JavaScriptValueType.Null:
+                    return VisitNull(value);
+                case JavaScriptValueType.Number:
+                    return VisitNumber(value);
+                case JavaScriptValueType.Object:
+                    return VisitObject(value);
+                case JavaScriptValueType.String:
+                    return VisitString(value);
+                case JavaScriptValueType.Undefined:
+                    return VisitUndefined(value);
+                case JavaScriptValueType.Function:
+                case JavaScriptValueType.Error:
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        private JToken VisitArray(JavaScriptValue value)
+        {
+            var array = new JArray();
+            var propertyId = JavaScriptPropertyId.FromString("length");
+            var length = (int)value.GetProperty(propertyId).ToDouble();
+            for (var i = 0; i < length; ++i)
+            {
+                var index = JavaScriptValue.FromInt32(i);
+                var element = value.GetIndexedProperty(index);
+                array.Add(Visit(element));
+            }
+
+            return array;
+        }
+
+        private JToken VisitBoolean(JavaScriptValue value)
+        {
+            return value.ToBoolean() ? s_true : s_false;
+        }
+
+        private JToken VisitNull(JavaScriptValue value)
+        {
+            return s_null;
+        }
+
+        private JToken VisitNumber(JavaScriptValue value)
+        {
+            var number = value.ToDouble();
+
+            return number % 1 == 0
+                    ? new JValue((long)number)
+                    : new JValue(number);
+        }
+
+        private JToken VisitObject(JavaScriptValue value)
+        {
+            var jsonObject = new JObject();
+            var properties = Visit(value.GetOwnPropertyNames()).ToObject<string[]>();
+            foreach (var property in properties)
+            {
+                var propertyId = JavaScriptPropertyId.FromString(property);
+                var propertyValue = value.GetProperty(propertyId);
+                jsonObject.Add(property, Visit(propertyValue));
+            }
+
+            return jsonObject;
+        }
+
+        private JToken VisitString(JavaScriptValue value)
+        {
+            return JValue.CreateString(value.ToString());
+        }
+
+        private JToken VisitUndefined(JavaScriptValue value)
+        {
+            return s_undefined;
+        }
+    }
+}

--- a/Electrino/win10/Electrino/test-app/main.js
+++ b/Electrino/win10/Electrino/test-app/main.js
@@ -10,18 +10,18 @@ var win = null;
 
 console.log("hello world starting, app is: ", app);
 
-function createWindow () {
-  // Create the browser window.
+function createWindow() {
+    // Create the browser window.
     win = new BrowserWindow({ width: 800, height: 600 });
 
     console.log("createWindow", BrowserWindow, win);
-  // and load the index.html of the app.
+    // and load the index.html of the app.
     win.loadURL(url.format({
         pathname: path.join("/test-app", 'index.html'),
         protocol: 'ms-appx-web:',
         slashes: true
     }));
-  // Emitted when the window is closed.
+    // Emitted when the window is closed.
     win.on('closed', function () {
         // Dereference the window object, usually you would store windows
         // in an array if your app supports multi windows, this is the time


### PR DESCRIPTION
- Add basic support to parse the object passed into the BrowserWindow constructor so that we can utilize the width and height properties to set the preferred window size of the application.

*This is kind of quick and dirty and I'm sure it can be cleaned up further